### PR TITLE
Updating outdated dependencies and addressing vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 999

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -108,7 +108,7 @@
 					<dependency>
 						<groupId>org.pitest</groupId>
 						<artifactId>pitest-junit5-plugin</artifactId>
-						<version>0.14</version>
+						<version>1.1.2</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,7 +91,7 @@
 			<plugin>
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>
-				<version>1.11.0</version>
+				<version>1.11.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,7 +91,7 @@
 			<plugin>
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>
-				<version>1.6.7</version>
+				<version>1.11.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,7 +59,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
-				<version>3.2.2</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>install-artifacts</id>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.9</version>
+			<version>2.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.6</version>
+			<version>2.8.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/hocon/pom.xml
+++ b/hocon/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>1.4.1</version>
+            <version>1.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.6</version>
+				<version>3.0.1</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<junit.version>5.7.2</junit.version>
+		<junit.version>5.9.2</junit.version>
 		<mockito.version>3.11.0</mockito.version>
 		<equalsverifier.version>3.6.1</equalsverifier.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<junit.version>5.9.2</junit.version>
-		<mockito.version>3.11.0</mockito.version>
+		<mockito.version>5.1.1</mockito.version>
 		<equalsverifier.version>3.6.1</equalsverifier.version>
 	</properties>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.1</version>
+					<version>3.10.1</version>
 					<configuration>
 						<!-- Compile module descriptor with Java 11 -->
 						<release>11</release>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.5.0</version>
 				<configuration>
 					<source>8</source>
 					<excludePackageNames>space.arim.dazzleconf.internal:space.arim.dazzleconf.internal.*</excludePackageNames>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M3</version>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>enforce-rules</id>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.0.0-M7</version>
 				<configuration>
 					<autoVersionSubmodules>true</autoVersionSubmodules>
 					<tagNameFormat>@{project.version}</tagNameFormat>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 		<junit.version>5.9.2</junit.version>
 		<mockito.version>5.1.1</mockito.version>
-		<equalsverifier.version>3.6.1</equalsverifier.version>
+		<equalsverifier.version>3.13.2</equalsverifier.version>
 	</properties>
 	
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.0.0-M5</version>
+					<version>3.0.0-M9</version>
 					<configuration>
 						<trimStackTrace>false</trimStackTrace>
 						<argLine>-XX:TieredStopAtLevel=1 -XX:-TieredCompilation</argLine>

--- a/snakeyaml/pom.xml
+++ b/snakeyaml/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.28</version>
+			<version>1.33</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Hi.

I've enabled Dependabot and updated outdated dependencies for the repository, including addressing multiple vulnerabilities in old versions of gson and snakeyaml.

I noticed that some tests are failing after updating snakeyaml to the latest version, and I'm currently investigating the issue. However, I cannot promise that I can fix the issue on my own. I wanted to bring this to your attention so that you're aware of the issue, and we can work together to address it.

I believe it's important for libraries to use up-to-date and secure dependencies, so I felt it was necessary to address the vulnerabilities in the outdated dependencies. If any additional changes were made, I will be sure to include them in this pull request.

Let me know if you have any questions or concerns.

Stacktrace for tests:
```
[ERROR] space.arim.dazzleconf.ext.snakeyaml.YamlWriterTest.writeComments(Factory)[2]  Time elapsed: 0.004 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected 13 lines, but only got 9
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertLinesMatch$LinesMatcher.fail(AssertLinesMatch.java:203)
        at org.junit.jupiter.api.AssertLinesMatch$LinesMatcher.assertLinesMatch(AssertLinesMatch.java:101)
        at org.junit.jupiter.api.AssertLinesMatch.assertLinesMatch(AssertLinesMatch.java:80)
        at org.junit.jupiter.api.AssertLinesMatch.assertLinesMatch(AssertLinesMatch.java:42)
        at org.junit.jupiter.api.Assertions.assertLinesMatch(Assertions.java:1600)
        at space.arim.dazzleconf.ext.snakeyaml@1.3.0-SNAPSHOT/space.arim.dazzleconf.ext.snakeyaml.YamlWriterTest.assertLinesMatch(YamlWriterTest.java:78)
        at space.arim.dazzleconf.ext.snakeyaml@1.3.0-SNAPSHOT/space.arim.dazzleconf.ext.snakeyaml.YamlWriterTest.writeComments(YamlWriterTest.java:170)
```

```
[ERROR] space.arim.dazzleconf.ext.snakeyaml.YamlWriterTest.writeCommentHeader(Factory)[2]  Time elapsed: 0.026 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected 4 lines, but only got 1
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertLinesMatch$LinesMatcher.fail(AssertLinesMatch.java:203)
        at org.junit.jupiter.api.AssertLinesMatch$LinesMatcher.assertLinesMatch(AssertLinesMatch.java:101)
        at org.junit.jupiter.api.AssertLinesMatch.assertLinesMatch(AssertLinesMatch.java:80)
        at org.junit.jupiter.api.AssertLinesMatch.assertLinesMatch(AssertLinesMatch.java:42)
        at org.junit.jupiter.api.Assertions.assertLinesMatch(Assertions.java:1600)
        at space.arim.dazzleconf.ext.snakeyaml@1.3.0-SNAPSHOT/space.arim.dazzleconf.ext.snakeyaml.YamlWriterTest.assertLinesMatch(YamlWriterTest.java:78)
        at space.arim.dazzleconf.ext.snakeyaml@1.3.0-SNAPSHOT/space.arim.dazzleconf.ext.snakeyaml.YamlWriterTest.writeCommentHeader(YamlWriterTest.java:201)
```
